### PR TITLE
Add terms of use and privacy policy to `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,32 @@ Python Dependencies
 ```sh
 pip install discord dotenv
 ```
+
+
+# Terms of Use
+
+As an administrator inviting this bot to a server, you agree to only grant the
+bot access to text channels with minimal posting activity to limit email spam.
+You also agree to add prominent warnings to these channels that posts to them
+will be forwarded by the bot to club students and/or their parents via email.
+
+You must seek and record the consent of monitored announcement channels'
+individual posters to share their Discord API data with this bot to fulfill its
+functions as described in the [Privacy Policy]( #privacy-policy ); Forward
+copies of recorded consent to the bot's owner through the club's official email
+address.  These restrictions are meant to comply with the [Discord Developer
+Terms of Service](
+https://support-dev.discord.com/hc/en-us/articles/8562894815383-Discord-Developer-Terms-of-Service
+).
+
+
+# Privacy Policy
+
+This bot does not persist any user data.  However, it does share message
+contents and authors' server nicknames that it sees in announcement channels (as
+assigned by server owners).  These messages get forwarded to limited mailing
+lists of the students and parents in Sage Creek High School's robotics club that
+cannot or refuse to join Discord.  The student and parent members of these
+mailing lists are the only third parties that receive shared data; it is not
+sold to them.  Because this bot is not operated by a for-profit company, it is
+exempt from the California Consumer Privacy Act (CCPA).


### PR DESCRIPTION
These sections of the GitHub HTML rendering are meant to be hotlinked from the bot's developer portal in order to comply with the [Discord Developer Terms of Service]( https://support-dev.discord.com/hc/en-us/articles/8562894815383-Discord-Developer-Terms-of-Service ).

I didn't modify my original Sage Creek-specific wording, so if you want this bot to be general purpose then it might need edits.

Addresses Issue #5.